### PR TITLE
Add modal for managing multiple player substitutions

### DIFF
--- a/src/components/GameView.tsx
+++ b/src/components/GameView.tsx
@@ -5,7 +5,6 @@ import { v4 as uuidv4 } from 'uuid';
 // import { useGame } from '../contexts/GameContext';
 import { Game, Substitution } from '../types';
 import { dbService } from '../services/db';
-import { on } from 'events';
 
 export const GameView: React.FC = () => {
   const { id } = useParams<{ id: string }>();

--- a/src/test/GameView.test.tsx
+++ b/src/test/GameView.test.tsx
@@ -52,7 +52,6 @@ describe('Game Operations', () => {
       expect(screen.getByText('Test Team')).toBeInTheDocument();
     });
 
-
     // Time adjustments
     [-1, -10, -30, 1, 10, 30].forEach(adjustment => {
       let timeBefore: number = parseInt(screen.getByTestId('clock-display').getAttribute('data-seconds') || '0');
@@ -69,28 +68,15 @@ describe('Game Operations', () => {
     expect(screen.getByText('Start')).toBeInTheDocument();
 
     // Substitutions
-    let player1 = screen.getByTestId('player-1');
-    
-    userEvent.click(within(player1).getByText('Sub In'));
+    userEvent.click(screen.getByText('Sub'));
     await waitFor(() => {
-      expect(within(player1).getByText('Sub Out')).toBeInTheDocument();
-
-    });
-    await waitFor(() => {
-      expect(mockUpdateGame).toHaveBeenCalledWith(
-        expect.objectContaining({
-          periods: expect.arrayContaining([
-            expect.objectContaining({
-              substitutions: expect.arrayContaining([
-                expect.objectContaining({ timeIn: expect.any(Number), timeOut: null })
-              ])
-            })
-          ])
-        })
-      );
+      expect(screen.getByText('Manage Substitutions')).toBeInTheDocument();
     });
 
-    userEvent.click(screen.getByText('Sub Out'));
+    let player1 = screen.getByText('Player 1');
+    userEvent.click(within(player1.closest('div')!).getByText('Out'));
+    userEvent.click(screen.getByText('Done'));
+
     await waitFor(() => {
       expect(mockUpdateGame).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -98,6 +84,29 @@ describe('Game Operations', () => {
             expect.objectContaining({
               substitutions: expect.arrayContaining([
                 expect.objectContaining({ timeOut: expect.any(Number) })
+              ])
+            })
+          ])
+        })
+      );
+    });
+
+    userEvent.click(screen.getByText('Sub'));
+    await waitFor(() => {
+      expect(screen.getByText('Manage Substitutions')).toBeInTheDocument();
+    });
+
+    let player2 = screen.getByText('Player 2');
+    userEvent.click(within(player2.closest('div')!).getByText('In'));
+    userEvent.click(screen.getByText('Done'));
+
+    await waitFor(() => {
+      expect(mockUpdateGame).toHaveBeenCalledWith(
+        expect.objectContaining({
+          periods: expect.arrayContaining([
+            expect.objectContaining({
+              substitutions: expect.arrayContaining([
+                expect.objectContaining({ timeIn: expect.any(Number) })
               ])
             })
           ])
@@ -123,4 +132,4 @@ describe('Game Operations', () => {
       );
     });
   });
-}); 
+});

--- a/src/test/GameView.test.tsx
+++ b/src/test/GameView.test.tsx
@@ -73,8 +73,8 @@ describe('Game Operations', () => {
       expect(screen.getByText('Manage Substitutions')).toBeInTheDocument();
     });
 
-    let player1 = screen.getByText('Player 1');
-    userEvent.click(within(player1.closest('div')!).getByText('Out'));
+    let player1 = within(screen.getByTestId('substitution-modal')).getByText('Player 1');
+    userEvent.click(within(player1.closest('div')!).getByText('In'));
     userEvent.click(screen.getByText('Done'));
 
     await waitFor(() => {
@@ -83,7 +83,7 @@ describe('Game Operations', () => {
           periods: expect.arrayContaining([
             expect.objectContaining({
               substitutions: expect.arrayContaining([
-                expect.objectContaining({ timeOut: expect.any(Number) })
+                expect.objectContaining({ timeIn: expect.any(Number) })
               ])
             })
           ])
@@ -96,8 +96,8 @@ describe('Game Operations', () => {
       expect(screen.getByText('Manage Substitutions')).toBeInTheDocument();
     });
 
-    let player2 = screen.getByText('Player 2');
-    userEvent.click(within(player2.closest('div')!).getByText('In'));
+    player1 = within(screen.getByTestId('substitution-modal')).getByText('Player 1');
+    userEvent.click(within(player1.closest('div')!).getByText('Out'));
     userEvent.click(screen.getByText('Done'));
 
     await waitFor(() => {
@@ -106,7 +106,7 @@ describe('Game Operations', () => {
           periods: expect.arrayContaining([
             expect.objectContaining({
               substitutions: expect.arrayContaining([
-                expect.objectContaining({ timeIn: expect.any(Number) })
+                expect.objectContaining({ timeOut: expect.any(Number) })
               ])
             })
           ])

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2015",
     "lib": [
       "dom",
       "dom.iterable",


### PR DESCRIPTION
Implement functionality to swap multiple players in a game through a new modal interface. Refactor existing substitution handling to accommodate this feature and update relevant tests. Remove unused imports to clean up the codebase.

Fixes #8