### PR TITLE
Update Renovate configuration for improved grouping

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,7 +3,10 @@
     "extends": [
         "config:best-practices",
         "schedule:automergeDaily",
-        "group:all"
+        "group:nodeJs",
+        "group:react",
+        "group:test",
+        "group:allNonMajor"
     ],
     "assignees": ["acbgbca"],
     "prHourlyLimit": 1,


### PR DESCRIPTION
Refine the Renovate configuration to include specific groups for Node.js, React, and tests, while maintaining a group for all non-major updates.