### PR TITLE
Revert TypeScript upgrade and adjust Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,5 +15,5 @@
     "minimumReleaseAge": "3 days",
     "commitMessagePrefix": "[Renovate] ",
     "automerge": true,
-    "platformAutomerge": true
+    "platformAutomerge": false
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "react-dom": "^19.0.0",
         "react-router-dom": "^6.22.0",
         "react-scripts": "5.0.1",
-        "typescript": "^5.0.0",
+        "typescript": "^4.9.5",
         "uuid": "^11.1.0",
         "web-vitals": "^2.1.4"
       }
@@ -16720,16 +16720,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=4.2.0"
       }
     },
     "node_modules/unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "react-dom": "^19.0.0",
     "react-router-dom": "^6.22.0",
     "react-scripts": "5.0.1",
-    "typescript": "^5.0.0",
+    "typescript": "^4.9.5",
     "uuid": "^11.1.0",
     "web-vitals": "^2.1.4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9315,10 +9315,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^5.0.0:
-  version "5.8.2"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz"
-  integrity sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==
+typescript@^4.9.5:
+  version "4.9.5"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz"
+  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
 unbox-primitive@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
Revert the TypeScript version to 4.9.5 and modify the Renovate configuration to prevent automatic merging before pipelines run.