### PR TITLE
Update Renovate configuration for PR limits and rebase

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,11 +9,12 @@
         "group:allNonMajor"
     ],
     "assignees": ["acbgbca"],
-    "prHourlyLimit": 2,
-    "prConcurrentLimit": 4,
+    "prHourlyLimit": 1,
+    "prConcurrentLimit": 2,
     "ignoreTests": false,
     "minimumReleaseAge": "3 days",
     "commitMessagePrefix": "[Renovate] ",
+    "rebaseWhen": "behind-base-branch",
     "automerge": true,
     "platformAutomerge": false
 }


### PR DESCRIPTION
Adjust PR limits to allow fewer concurrent and hourly requests, and enable rebase when behind the base branch.