### PR TITLE
Streamline Team creation #82

### DIFF
--- a/e2e/game.spec.ts
+++ b/e2e/game.spec.ts
@@ -2,12 +2,13 @@ import { test, expect } from '@playwright/test';
 
 test.describe('Game Management', () => {
   test('should create a new game', async ({ page }) => {
-    // First create a team
-    await page.goto('/#/teams/new');
-    await page.waitForSelector('#teamName', { timeout: 5000 });
+    // First create a team using modal
+    await page.goto('/#/teams');
+    await page.getByRole('button', { name: 'Add New Team' }).click();
     await page.fill('#teamName', 'Game Test Team');
     await page.getByRole('button', { name: 'Create Team' }).click();
-    await expect(page).toHaveURL('/#/teams');
+    await page.waitForURL(/\/#\/teams\/.*$/, { timeout: 5000 });
+    await page.goto('/#/teams');
 
     // Create a new game
     await page.goto('/#/games/new');
@@ -22,17 +23,14 @@ test.describe('Game Management', () => {
   });
 
   test('should create a new game with auto-selected players', async ({ page }) => {
-    // First create a team with players
-    await page.goto('/#/teams/new');
-    await page.waitForSelector('#teamName', { timeout: 5000 });
+    // First create a team with players using modal
+    await page.goto('/#/teams');
+    await page.getByRole('button', { name: 'Add New Team' }).click();
     await page.fill('#teamName', 'Auto Select Team');
     await page.getByRole('button', { name: 'Create Team' }).click();
-    await expect(page).toHaveURL('/#/teams');
-    
-    // Add players
-    await page.getByTestId('view-team-Auto Select Team').click();
     await page.waitForURL(/\/#\/teams\/.*$/, { timeout: 5000 });
     
+    // Add players
     // Add player 1
     await page.getByRole('button', { name: 'Add Player' }).click();
     const rows = await page.getByRole('row').all();
@@ -73,12 +71,13 @@ test.describe('Game Management', () => {
   });
 
   test('should manage game clock', async ({ page }) => {
-    // Create team and game first
-    await page.goto('/#/teams/new');
-    await page.waitForSelector('#teamName', { timeout: 5000 });
+    // Create team using modal and game first
+    await page.goto('/#/teams');
+    await page.getByRole('button', { name: 'Add New Team' }).click();
     await page.fill('#teamName', 'Clock Test Team');
     await page.getByRole('button', { name: 'Create Team' }).click();
-    await expect(page).toHaveURL('/#/teams');
+    await page.waitForURL(/\/#\/teams\/.*$/, { timeout: 5000 });
+    await page.goto('/#/teams');
 
     await page.goto('/#/games/new');
     await page.waitForSelector('[data-testid="team-select"]', { timeout: 5000 });
@@ -115,17 +114,14 @@ test.describe('Game Management', () => {
   });
 
   test('should manage substitutions', async ({ page }) => {
-    // Create team with players
-    await page.goto('/#/teams/new');
-    await page.waitForSelector('#teamName', { timeout: 5000 });
+    // Create team with players using modal
+    await page.goto('/#/teams');
+    await page.getByRole('button', { name: 'Add New Team' }).click();
     await page.fill('#teamName', 'Sub Test Team');
     await page.getByRole('button', { name: 'Create Team' }).click();
-    await expect(page).toHaveURL('/#/teams');
-    
-    // Add players
-    await page.getByTestId('view-team-Sub Test Team').click();
     await page.waitForURL(/\/#\/teams\/.*$/, { timeout: 5000 });
     
+    // Add players
     // Add player 1
     await page.getByRole('button', { name: 'Add Player' }).click();
     const rows = await page.getByRole('row').all();
@@ -176,17 +172,14 @@ test.describe('Game Management', () => {
   });
 
   test('should enforce maximum of 5 players on court', async ({ page }) => {
-    // Create team with 7 players
-    await page.goto('/#/teams/new');
-    await page.waitForSelector('#teamName', { timeout: 5000 });
+    // Create team with 7 players using modal
+    await page.goto('/#/teams');
+    await page.getByRole('button', { name: 'Add New Team' }).click();
     await page.fill('#teamName', 'Max Players Team');
     await page.getByRole('button', { name: 'Create Team' }).click();
-    await expect(page).toHaveURL('/#/teams');
-    
-    // Add players
-    await page.getByTestId('view-team-Max Players Team').click();
     await page.waitForURL(/\/#\/teams\/.*$/, { timeout: 5000 });
     
+    // Add players
     // Add 7 players
     for (let i = 1; i <= 7; i++) {
       await page.getByRole('button', { name: 'Add Player' }).click();
@@ -235,17 +228,14 @@ test.describe('Game Management', () => {
   });
 
   test('should track player fouls', async ({ page }) => {
-    // Create team with players
-    await page.goto('/#/teams/new');
-    await page.waitForSelector('#teamName', { timeout: 5000 });
+    // Create team with players using modal
+    await page.goto('/#/teams');
+    await page.getByRole('button', { name: 'Add New Team' }).click();
     await page.fill('#teamName', 'Foul Test Team');
     await page.getByRole('button', { name: 'Create Team' }).click();
-    await expect(page).toHaveURL('/#/teams');
-    
-    // Add players
-    await page.getByTestId('view-team-Foul Test Team').click();
     await page.waitForURL(/\/#\/teams\/.*$/, { timeout: 5000 });
     
+    // Add players
     // Add test player
     await page.getByRole('button', { name: 'Add Player' }).click();
     const rows = await page.getByRole('row').all();

--- a/e2e/game.spec.ts
+++ b/e2e/game.spec.ts
@@ -34,21 +34,21 @@ test.describe('Game Management', () => {
     await page.waitForURL(/\/#\/teams\/.*$/, { timeout: 5000 });
     
     // Add player 1
-    await page.getByRole('button', { name: 'Add Player' }).first().click();
-    await page.waitForSelector('#playerName', { timeout: 5000 });
-    await page.fill('#playerName', 'Auto Player 1');
-    await page.fill('#playerNumber', '1');
-    await page.getByTestId('add-player-button').click();
-    
-    // Wait for first player to be added before adding second
-    await expect(page.getByText('Auto Player 1')).toBeVisible({ timeout: 5000 });
+    await page.getByRole('button', { name: 'Add Player' }).click();
+    const rows = await page.getByRole('row').all();
+    let lastRow = rows[rows.length - 1];
+    await lastRow.getByLabel('Player Number').fill('1');
+    await lastRow.getByLabel('Player Name').fill('Auto Player 1');
     
     // Add player 2
-    await page.getByRole('button', { name: 'Add Player' }).first().click();
-    await page.waitForSelector('#playerName', { timeout: 5000 });
-    await page.fill('#playerName', 'Auto Player 2');
-    await page.fill('#playerNumber', '2');
-    await page.getByTestId('add-player-button').click();
+    await page.getByRole('button', { name: 'Add Player' }).click();
+    const updatedRows = await page.getByRole('row').all();
+    lastRow = updatedRows[updatedRows.length - 1];
+    await lastRow.getByLabel('Player Number').fill('2');
+    await lastRow.getByLabel('Player Name').fill('Auto Player 2');
+    
+    // Save the changes
+    await page.getByRole('button', { name: 'Save Changes' }).click();
 
     // Create game
     await page.goto('/#/games/new');
@@ -126,20 +126,22 @@ test.describe('Game Management', () => {
     await page.getByTestId('view-team-Sub Test Team').click();
     await page.waitForURL(/\/#\/teams\/.*$/, { timeout: 5000 });
     
-    // Explicitly wait for the Add Player button and use first() to handle multiple matches
-    await page.getByRole('button', { name: 'Add Player' }).first().click();
-    await page.waitForSelector('#playerName', { timeout: 5000 });
-    await page.fill('#playerName', 'Player One');
-    await page.fill('#playerNumber', '1');
-    await page.getByTestId('add-player-button').click();
+    // Add player 1
+    await page.getByRole('button', { name: 'Add Player' }).click();
+    const rows = await page.getByRole('row').all();
+    let lastRow = rows[rows.length - 1];
+    await lastRow.getByLabel('Player Number').fill('1');
+    await lastRow.getByLabel('Player Name').fill('Player One');
     
-    // Wait for the first player to be added before adding the second
-    await expect(page.getByText('Player One')).toBeVisible({ timeout: 5000 });
-    await page.getByRole('button', { name: 'Add Player' }).first().click();
-    await page.waitForSelector('#playerName', { timeout: 5000 });
-    await page.fill('#playerName', 'Player Two');
-    await page.fill('#playerNumber', '2');
-    await page.getByTestId('add-player-button').click();
+    // Add player 2
+    await page.getByRole('button', { name: 'Add Player' }).click();
+    const updatedRows = await page.getByRole('row').all();
+    lastRow = updatedRows[updatedRows.length - 1];
+    await lastRow.getByLabel('Player Number').fill('2');
+    await lastRow.getByLabel('Player Name').fill('Player Two');
+    
+    // Save the changes
+    await page.getByRole('button', { name: 'Save Changes' }).click();
 
     // Create game
     await page.goto('/#/games/new');
@@ -187,14 +189,15 @@ test.describe('Game Management', () => {
     
     // Add 7 players
     for (let i = 1; i <= 7; i++) {
-      await page.getByRole('button', { name: 'Add Player' }).first().click();
-      await page.waitForSelector('#playerName', { timeout: 5000 });
-      await page.fill('#playerName', `Max Player ${i}`);
-      await page.fill('#playerNumber', i.toString());
-      await page.getByTestId('add-player-button').click();
-      // Wait for the player to be added before continuing
-      await expect(page.getByText(`Max Player ${i}`)).toBeVisible({ timeout: 5000 });
+      await page.getByRole('button', { name: 'Add Player' }).click();
+      const rows = await page.getByRole('row').all();
+      const lastRow = rows[rows.length - 1];
+      await lastRow.getByLabel('Player Number').fill(i.toString());
+      await lastRow.getByLabel('Player Name').fill(`Max Player ${i}`);
     }
+    
+    // Save the changes
+    await page.getByRole('button', { name: 'Save Changes' }).click();
 
     // Create game
     await page.goto('/#/games/new');
@@ -244,11 +247,14 @@ test.describe('Game Management', () => {
     await page.waitForURL(/\/#\/teams\/.*$/, { timeout: 5000 });
     
     // Add test player
-    await page.getByRole('button', { name: 'Add Player' }).first().click();
-    await page.waitForSelector('#playerName', { timeout: 5000 });
-    await page.fill('#playerName', 'Foul Player');
-    await page.fill('#playerNumber', '1');
-    await page.getByTestId('add-player-button').click();
+    await page.getByRole('button', { name: 'Add Player' }).click();
+    const rows = await page.getByRole('row').all();
+    const lastRow = rows[rows.length - 1];
+    await lastRow.getByLabel('Player Number').fill('1');
+    await lastRow.getByLabel('Player Name').fill('Foul Player');
+    
+    // Save the changes
+    await page.getByRole('button', { name: 'Save Changes' }).click();
 
     // Create game
     await page.goto('/#/games/new');

--- a/e2e/period.spec.ts
+++ b/e2e/period.spec.ts
@@ -2,12 +2,13 @@ import { test, expect } from '@playwright/test';
 
 test.describe('Period Management', () => {
   test('should handle periods in a game', async ({ page }) => {
-    // Setup team and game
-    await page.goto('/#/teams/new');
-    await page.waitForSelector('#teamName', { timeout: 5000 });
+    // Setup team and game using modal
+    await page.goto('/#/teams');
+    await page.getByRole('button', { name: 'Add New Team' }).click();
     await page.fill('#teamName', 'Period Test Team');
     await page.getByRole('button', { name: 'Create Team' }).click();
-    await expect(page).toHaveURL('/#/teams');
+    await page.waitForURL(/\/#\/teams\/.*$/, { timeout: 5000 });
+    await page.goto('/#/teams');
 
     await page.goto('/#/games/new');
     await page.waitForSelector('[data-testid="team-select"]', { timeout: 5000 });
@@ -52,16 +53,14 @@ test.describe('Period Management', () => {
   });
 
   test('should track substitutions across periods', async ({ page }) => {
-    // Setup team with players
-    await page.goto('/#/teams/new');
-    await page.waitForSelector('#teamName', { timeout: 5000 });
+    // Setup team with players using modal
+    await page.goto('/#/teams');
+    await page.getByRole('button', { name: 'Add New Team' }).click();
     await page.fill('#teamName', 'Sub Period Team');
     await page.getByRole('button', { name: 'Create Team' }).click();
-    await expect(page).toHaveURL('/#/teams');
+    await page.waitForURL(/\/#\/teams\/.*$/, { timeout: 5000 });
     
     // Add a player
-    await page.getByTestId('view-team-Sub Period Team').click();
-    await page.waitForURL(/\/#\/teams\/.*$/, { timeout: 5000 });
     await page.getByRole('button', { name: 'Add Player' }).click();
     const rows = await page.getByRole('row').all();
     const lastRow = rows[rows.length - 1];

--- a/e2e/period.spec.ts
+++ b/e2e/period.spec.ts
@@ -62,11 +62,14 @@ test.describe('Period Management', () => {
     // Add a player
     await page.getByTestId('view-team-Sub Period Team').click();
     await page.waitForURL(/\/#\/teams\/.*$/, { timeout: 5000 });
-    await page.getByRole('button', { name: 'Add Player' }).first().click();
-    await page.waitForSelector('#playerName', { timeout: 5000 });
-    await page.fill('#playerName', 'Test Player');
-    await page.fill('#playerNumber', '10');
-    await page.getByTestId('add-player-button').click();
+    await page.getByRole('button', { name: 'Add Player' }).click();
+    const rows = await page.getByRole('row').all();
+    const lastRow = rows[rows.length - 1];
+    await lastRow.getByLabel('Player Number').fill('10');
+    await lastRow.getByLabel('Player Name').fill('Test Player');
+    
+    // Save the changes
+    await page.getByRole('button', { name: 'Save Changes' }).click();
 
     // Create game with quarters
     await page.goto('/#/games/new');

--- a/e2e/team.spec.ts
+++ b/e2e/team.spec.ts
@@ -1,44 +1,40 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('Team Management', () => {
-  test('should create a new team', async ({ page }) => {
-    await page.goto('/#/teams/new');
-    // Wait for navigation and form to be ready
-    await page.waitForSelector('#teamName');
+  test('should create a new team and navigate to team view', async ({ page }) => {
+    await page.goto('/#/teams');
+    await page.getByRole('button', { name: 'Add New Team' }).click();
     
     await page.fill('#teamName', 'Test Team');
     await page.getByRole('button', { name: 'Create Team' }).click();
-    await expect(page).toHaveURL('/#/teams');
-    await expect(page.getByText('Test Team')).toBeVisible();
-  });
-
-  test('should view team details', async ({ page }) => {
+    
+    // Should navigate to team view
+    await page.waitForURL(/\/#\/teams\/.*$/, { timeout: 5000 });
+    await expect(page.getByLabel('Team Name')).toHaveValue('Test Team');
+  });  test('should view team details', async ({ page }) => {
     // First create a team
-    await page.goto('/#/teams/new');
-    await page.waitForSelector('#teamName');
+    await page.goto('/#/teams');
+    await page.getByRole('button', { name: 'Add New Team' }).click();
     await page.fill('#teamName', 'View Test Team');
     await page.getByRole('button', { name: 'Create Team' }).click();
-    await expect(page).toHaveURL('/#/teams');
     
-    // Then view its details
-    await page.getByRole('button', { name: 'View Team' }).click();
+    // Should go directly to team view
     await page.waitForURL(/\/#\/teams\/.*$/, { timeout: 5000 });
     await expect(page.getByLabel('Team Name')).toHaveValue('View Test Team');
   });
 
   test('should add a player to team', async ({ page }) => {
     // First create a team
-    await page.goto('/#/teams/new');
-    await page.waitForSelector('#teamName');
+    await page.goto('/#/teams');
+    await page.getByRole('button', { name: 'Add New Team' }).click();
     await page.fill('#teamName', 'Player Test Team');
     await page.getByRole('button', { name: 'Create Team' }).click();
-    await expect(page).toHaveURL('/#/teams');
     
-    // Navigate to team view and add player
-    await page.getByRole('button', { name: 'View Team' }).click();
+    // Should navigate to team view page
+    await page.waitForURL(/\/#\/teams\/.*$/, { timeout: 5000 });
+    
+    // Add player
     await page.getByRole('button', { name: 'Add Player' }).click();
-    
-    // Fill in the new player row that appears in the table
     const rows = await page.getByRole('row').all();
     const lastRow = rows[rows.length - 1]; // New player is added at the end
     
@@ -56,15 +52,13 @@ test.describe('Team Management', () => {
   });
 
   test('should edit team name', async ({ page }) => {
-    // First create a team
-    await page.goto('/#/teams/new');
-    await page.waitForSelector('#teamName');
+    // First create a team using modal
+    await page.goto('/#/teams');
+    await page.getByRole('button', { name: 'Add New Team' }).click();
     await page.fill('#teamName', 'Edit Name Team');
     await page.getByRole('button', { name: 'Create Team' }).click();
-    await expect(page).toHaveURL('/#/teams');
     
-    // Navigate to team view
-    await page.getByTestId('view-team-Edit Name Team').click();
+    // Should navigate to team view page
     await page.waitForURL(/\/#\/teams\/.*$/, { timeout: 5000 });
     
     // Edit team name

--- a/e2e/team.spec.ts
+++ b/e2e/team.spec.ts
@@ -36,13 +36,22 @@ test.describe('Team Management', () => {
     // Navigate to team view and add player
     await page.getByRole('button', { name: 'View Team' }).click();
     await page.getByRole('button', { name: 'Add Player' }).click();
-    await page.waitForSelector('#playerName');
-    await page.fill('#playerName', 'John Doe');
-    await page.fill('#playerNumber', '23');
-    await page.getByTestId('add-player-button').click();
     
-    await expect(page.getByText('John Doe')).toBeVisible();
-    await expect(page.getByText('23')).toBeVisible();
+    // Fill in the new player row that appears in the table
+    const rows = await page.getByRole('row').all();
+    const lastRow = rows[rows.length - 1]; // New player is added at the end
+    
+    // Fill in player details in the table inputs
+    await lastRow.getByLabel('Player Number').fill('23');
+    await lastRow.getByLabel('Player Name').fill('John Doe');
+    
+    // Save the changes
+    await page.getByRole('button', { name: 'Save Changes' }).click();
+    
+    // Verify the player appears in the table
+    await expect(page.getByTestId('player-23')).toBeVisible();
+    await expect(page.getByTestId('player-23').getByLabel('Player Name')).toHaveValue('John Doe');
+    await expect(page.getByTestId('player-23').getByLabel('Player Number')).toHaveValue('23');
   });
 });
 

--- a/e2e/team.spec.ts
+++ b/e2e/team.spec.ts
@@ -22,7 +22,8 @@ test.describe('Team Management', () => {
     
     // Then view its details
     await page.getByRole('button', { name: 'View Team' }).click();
-    await expect(page.getByRole('heading')).toContainText('View Test Team');
+    await page.waitForURL(/\/#\/teams\/.*$/, { timeout: 5000 });
+    await expect(page.getByLabel('Team Name')).toHaveValue('View Test Team');
   });
 
   test('should add a player to team', async ({ page }) => {
@@ -52,6 +53,30 @@ test.describe('Team Management', () => {
     await expect(page.getByTestId('player-23')).toBeVisible();
     await expect(page.getByTestId('player-23').getByLabel('Player Name')).toHaveValue('John Doe');
     await expect(page.getByTestId('player-23').getByLabel('Player Number')).toHaveValue('23');
+  });
+
+  test('should edit team name', async ({ page }) => {
+    // First create a team
+    await page.goto('/#/teams/new');
+    await page.waitForSelector('#teamName');
+    await page.fill('#teamName', 'Edit Name Team');
+    await page.getByRole('button', { name: 'Create Team' }).click();
+    await expect(page).toHaveURL('/#/teams');
+    
+    // Navigate to team view
+    await page.getByTestId('view-team-Edit Name Team').click();
+    await page.waitForURL(/\/#\/teams\/.*$/, { timeout: 5000 });
+    
+    // Edit team name
+    const teamNameInput = page.getByLabel('Team Name');
+    await teamNameInput.clear();
+    await teamNameInput.fill('Updated Team Name');
+    
+    // Save changes
+    await page.getByRole('button', { name: 'Save Changes' }).click();
+    
+    // Verify updates are saved - should show the new name
+    await expect(page.getByLabel('Team Name')).toHaveValue('Updated Team Name');
   });
 });
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,7 +28,6 @@ function App() {
         <Routes>
           <Route path="/" element={<GameList />} />
           <Route path="/teams" element={<TeamList />} />
-          <Route path="/teams/new" element={<TeamForm />} />
           <Route path="/games" element={<GameList />} />
           <Route path="/games/new" element={<GameForm />} />
           <Route path="/games/:id" element={<GameView />} />

--- a/src/components/TeamForm.tsx
+++ b/src/components/TeamForm.tsx
@@ -5,7 +5,13 @@ import { Team } from '../types';
 import { dbService } from '../services/db';
 import { useNavigate } from 'react-router-dom';
 
-export const TeamForm: React.FC = () => {
+interface TeamFormProps {
+  isModal?: boolean;
+  onClose?: () => void;
+  onTeamCreated?: (team: Team) => void;
+}
+
+export const TeamForm: React.FC<TeamFormProps> = ({ isModal, onClose, onTeamCreated }) => {
   const [teamName, setTeamName] = useState('');
   const navigate = useNavigate();
 
@@ -20,31 +26,53 @@ export const TeamForm: React.FC = () => {
 
     try {
       await dbService.addTeam(newTeam);
-      // Redirect to team list
-      navigate('/teams');
+      // Always notify parent about team creation
+      if (isModal) {
+        onTeamCreated?.(newTeam);
+        onClose?.();
+      }
+      // Always navigate to new team's view page
+      navigate(`/teams/${newTeam.id}`);
     } catch (error) {
       console.error('Error creating team:', error);
     }
   };
 
-  return (
-    <Container>
-      <h2>Create New Team</h2>
-      <Form onSubmit={handleSubmit}>
-        <Form.Group className="mb-3">
-          <Form.Label htmlFor="teamName">Team Name</Form.Label>
-          <Form.Control
-            id="teamName"
-            type="text"
-            value={teamName}
-            onChange={(e) => setTeamName(e.target.value)}
-            required
-          />
-        </Form.Group>
+  const content = (
+    <Form onSubmit={handleSubmit}>
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="teamName">Team Name</Form.Label>
+        <Form.Control
+          id="teamName"
+          type="text"
+          value={teamName}
+          onChange={(e) => setTeamName(e.target.value)}
+          required
+        />
+      </Form.Group>
+      <div className="d-flex gap-2">
+        {isModal && (
+          <Button variant="secondary" onClick={onClose}>
+            Cancel
+          </Button>
+        )}
         <Button variant="primary" type="submit">
           Create Team
         </Button>
-      </Form>
+      </div>
+    </Form>
+  );
+
+  // If used in modal mode, just return the form content
+  if (isModal) {
+    return content;
+  }
+
+  // If used as a standalone page, wrap in container with title
+  return (
+    <Container>
+      <h2>Create New Team</h2>
+      {content}
     </Container>
   );
-}; 
+};

--- a/src/components/TeamList.tsx
+++ b/src/components/TeamList.tsx
@@ -3,10 +3,12 @@ import { Container, Row, Col, Card, Button, Modal } from 'react-bootstrap';
 import { Link } from 'react-router-dom';
 import { Team } from '../types';
 import { dbService } from '../services/db';
+import { TeamForm } from './TeamForm';
 
 export const TeamList: React.FC = () => {
   const [teams, setTeams] = useState<Team[]>([]);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [showNewTeamModal, setShowNewTeamModal] = useState(false);
   const [teamToDelete, setTeamToDelete] = useState<Team | null>(null);
 
   useEffect(() => {
@@ -35,14 +37,18 @@ export const TeamList: React.FC = () => {
     }
   };
 
+  const handleTeamCreated = (newTeam: Team) => {
+    setTeams([...teams, newTeam]);
+  };
+
   return (
     <Container>
       <Row className="mb-4">
         <Col>
           <h2>Teams</h2>
-          <Link to="/teams/new">
-            <Button variant="primary">Add New Team</Button>
-          </Link>
+          <Button variant="primary" onClick={() => setShowNewTeamModal(true)}>
+            Add New Team
+          </Button>
         </Col>
       </Row>
       <Row>
@@ -71,6 +77,20 @@ export const TeamList: React.FC = () => {
         ))}
       </Row>
 
+      {/* New Team Modal */}
+      <Modal show={showNewTeamModal} onHide={() => setShowNewTeamModal(false)}>
+        <Modal.Header closeButton>
+          <Modal.Title>Create New Team</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <TeamForm 
+            isModal={true} 
+            onClose={() => setShowNewTeamModal(false)}
+            onTeamCreated={handleTeamCreated}
+          />
+        </Modal.Body>
+      </Modal>
+
       {/* Delete Confirmation Modal */}
       <Modal show={showDeleteModal} onHide={() => setShowDeleteModal(false)}>
         <Modal.Header closeButton>
@@ -95,4 +115,4 @@ export const TeamList: React.FC = () => {
       </Modal>
     </Container>
   );
-}; 
+};

--- a/src/components/TeamView.tsx
+++ b/src/components/TeamView.tsx
@@ -138,18 +138,18 @@ export const TeamView: React.FC = () => {
               ))}
             </tbody>
           </Table>
-          <div className="d-flex justify-content-between mt-3">
+          <div className="d-flex flex-column flex-md-row justify-content-between mt-3 gap-3">
             <Button 
               variant="primary" 
               onClick={handleAddPlayer}
+              className="w-md-auto"
             >
               Add Player
             </Button>
-            <div>
+            <div className="d-flex gap-2 justify-content-end">
               <Button 
                 variant="secondary" 
                 onClick={handleCancel}
-                className="me-2"
               >
                 Cancel
               </Button>
@@ -157,7 +157,6 @@ export const TeamView: React.FC = () => {
                 variant="success" 
                 onClick={handleSave}
                 disabled={!hasChanges}
-                className="me-2"
               >
                 Save Changes
               </Button>

--- a/src/components/TeamView.tsx
+++ b/src/components/TeamView.tsx
@@ -10,6 +10,7 @@ export const TeamView: React.FC = () => {
   const navigate = useNavigate();
   const [team, setTeam] = useState<Team | null>(null);
   const [editedPlayers, setEditedPlayers] = useState<Player[]>([]);
+  const [editedTeamName, setEditedTeamName] = useState('');
   const [hasChanges, setHasChanges] = useState(false);
 
   useEffect(() => {
@@ -18,6 +19,7 @@ export const TeamView: React.FC = () => {
         const teamData = await dbService.getTeam(id);
         setTeam(teamData);
         setEditedPlayers(teamData?.players || []);
+        setEditedTeamName(teamData?.name || '');
       }
     };
     loadTeam();
@@ -47,11 +49,17 @@ export const TeamView: React.FC = () => {
     setHasChanges(true);
   };
 
+  const handleTeamNameChange = (value: string) => {
+    setEditedTeamName(value);
+    setHasChanges(true);
+  };
+
   const handleSave = async () => {
     if (!team) return;
 
     const updatedTeam: Team = {
       ...team,
+      name: editedTeamName,
       players: editedPlayers
     };
 
@@ -74,7 +82,15 @@ export const TeamView: React.FC = () => {
     <Container>
       <Row className="mb-4">
         <Col>
-          <h2>{team.name}</h2>
+          <Form.Control
+            type="text"
+            value={editedTeamName}
+            onChange={(e) => handleTeamNameChange(e.target.value)}
+            className="h2 border-0 bg-transparent"
+            style={{ fontSize: '2rem' }}
+            required
+            aria-label="Team Name"
+          />
         </Col>
       </Row>
 

--- a/src/components/TeamView.tsx
+++ b/src/components/TeamView.tsx
@@ -58,10 +58,13 @@ export const TeamView: React.FC = () => {
     await dbService.updateTeam(updatedTeam);
     setTeam(updatedTeam);
     setHasChanges(false);
-    navigate('/teams');
   };
 
   const handleCancel = () => {
+    navigate('/teams');
+  };
+
+  const handleDone = () => {
     navigate('/teams');
   };
 
@@ -94,6 +97,7 @@ export const TeamView: React.FC = () => {
                       value={player.number}
                       onChange={(e) => handlePlayerChange(player.id, 'number', e.target.value)}
                       required
+                      aria-label="Player Number"
                     />
                   </td>
                   <td>
@@ -102,6 +106,7 @@ export const TeamView: React.FC = () => {
                       value={player.name}
                       onChange={(e) => handlePlayerChange(player.id, 'name', e.target.value)}
                       required
+                      aria-label="Player Name"
                     />
                   </td>
                   <td>
@@ -136,8 +141,15 @@ export const TeamView: React.FC = () => {
                 variant="success" 
                 onClick={handleSave}
                 disabled={!hasChanges}
+                className="me-2"
               >
                 Save Changes
+              </Button>
+              <Button 
+                variant="primary" 
+                onClick={handleDone}
+              >
+                Done
               </Button>
             </div>
           </div>

--- a/src/components/TeamView.tsx
+++ b/src/components/TeamView.tsx
@@ -99,7 +99,7 @@ export const TeamView: React.FC = () => {
           <Table striped bordered hover>
             <thead>
               <tr>
-                <th>Number</th>
+                <th style={{ width: '100px' }}>Number</th>
                 <th>Name</th>
                 <th>Actions</th>
               </tr>
@@ -110,10 +110,14 @@ export const TeamView: React.FC = () => {
                   <td>
                     <Form.Control
                       type="text"
+                      inputMode="numeric"
+                      pattern="[0-9]*"
+                      maxLength={3}
                       value={player.number}
                       onChange={(e) => handlePlayerChange(player.id, 'number', e.target.value)}
                       required
                       aria-label="Player Number"
+                      style={{ width: '80px' }}
                     />
                   </td>
                   <td>

--- a/src/test/TeamOperations.test.tsx
+++ b/src/test/TeamOperations.test.tsx
@@ -85,9 +85,10 @@ describe('Team Operations', () => {
 
     // Add player
     await userEvent.click(screen.getByText('Add Player'));
-    await userEvent.type(screen.getByLabelText('Name'), 'New Player');
-    await userEvent.type(screen.getByLabelText('Number'), '24');
-    await userEvent.click(screen.getByTestId('add-player-button'));
+    const inputs = screen.getAllByRole('textbox');
+    await userEvent.type(inputs[inputs.length - 2], '24'); // Number input comes first
+    await userEvent.type(inputs[inputs.length - 1], 'New Player');  // Name input comes second
+    await userEvent.click(screen.getByText('Save Changes'));
 
     await waitFor(() => {
       expect(mockUpdateTeam).toHaveBeenCalledWith(
@@ -100,10 +101,10 @@ describe('Team Operations', () => {
     });
 
     // Edit player
-    let playerRow = screen.getByTestId('player-24')
-    await userEvent.click(within(playerRow).getByText('Edit'));
-    await userEvent.clear(screen.getByLabelText('Name'));
-    await userEvent.type(screen.getByLabelText('Name'), 'Updated Player')
+    const allInputs = screen.getAllByRole('textbox');
+    const nameInputs = allInputs.filter(input => input.getAttribute('value') === 'New Player');
+    await userEvent.clear(nameInputs[0]);
+    await userEvent.type(nameInputs[0], 'Updated Player');
     await userEvent.click(screen.getByText('Save Changes'));
 
     await waitFor(() => {
@@ -116,8 +117,9 @@ describe('Team Operations', () => {
       );
     });
 
-    // Delete player
-    await userEvent.click(within(playerRow).getByText('Remove'));
+    // Delete player and save changes
+    await userEvent.click(screen.getByText('Remove'));
+    await userEvent.click(screen.getByText('Save Changes'));
 
     await waitFor(() => {
       expect(mockUpdateTeam).toHaveBeenCalledWith(
@@ -127,4 +129,4 @@ describe('Team Operations', () => {
       );
     });
   });
-}); 
+});

--- a/src/test/TeamOperations.test.tsx
+++ b/src/test/TeamOperations.test.tsx
@@ -80,7 +80,7 @@ describe('Team Operations', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText('Test Team')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('Test Team')).toBeInTheDocument();
     });
 
     // Add player
@@ -125,6 +125,47 @@ describe('Team Operations', () => {
       expect(mockUpdateTeam).toHaveBeenCalledWith(
         expect.objectContaining({
           players: []
+        })
+      );
+    });
+  });
+
+  test('edits team name', async () => {
+    const mockTeam = { 
+      id: '1', 
+      name: 'Test Team', 
+      players: []
+    };
+    
+    const mockUpdateTeam = jest.spyOn(dbService, 'updateTeam');
+    jest.spyOn(dbService, 'getTeam').mockResolvedValue(mockTeam);
+
+    render(
+      <MemoryRouter initialEntries={['/teams/1']}>
+        <Routes>
+          <Route path="/teams/:id" element={<TeamView />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    // Wait for team to load
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Test Team')).toBeInTheDocument();
+    });
+
+    // Edit team name
+    const teamNameInput = screen.getByDisplayValue('Test Team');
+    await userEvent.clear(teamNameInput);
+    await userEvent.type(teamNameInput, 'Updated Team Name');
+
+    // Save changes
+    await userEvent.click(screen.getByText('Save Changes'));
+
+    // Verify team was updated with new name
+    await waitFor(() => {
+      expect(mockUpdateTeam).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'Updated Team Name'
         })
       );
     });

--- a/src/test/TeamOperations.test.tsx
+++ b/src/test/TeamOperations.test.tsx
@@ -14,18 +14,48 @@ describe('Team Operations', () => {
     jest.clearAllMocks();
   });
 
-  test('creates a new team', async () => {
+  test('creates a new team from modal', async () => {
+    const mockAddTeam = jest.spyOn(dbService, 'addTeam');
+    jest.spyOn(dbService, 'getTeams').mockResolvedValue([]);
+    
+    render(
+      <MemoryRouter>
+        <TeamList />
+      </MemoryRouter>
+    );
+
+    // Open the modal
+    await userEvent.click(screen.getByText('Add New Team'));
+    
+    // Fill out and submit the form
+    await userEvent.type(screen.getByLabelText('Team Name'), 'Test Team');
+    await userEvent.click(screen.getByText('Create Team'));
+
+    // Verify team was created with correct data
+    await waitFor(() => {
+      expect(mockAddTeam).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'Test Team',
+          players: []
+        })
+      );
+    });
+  });
+
+  test('creates a new team from standalone page and navigates to team view', async () => {
     const mockAddTeam = jest.spyOn(dbService, 'addTeam');
     
     render(
       <MemoryRouter>
-        <TeamForm />
+        <Routes>
+          <Route path="/" element={<TeamForm />} />
+          <Route path="/teams/:id" element={<TeamView />} />
+        </Routes>
       </MemoryRouter>
     );
 
-    userEvent.type(screen.getByLabelText('Team Name'), 'Test Team');
-
-    userEvent.click(screen.getByText('Create Team'));
+    await userEvent.type(screen.getByLabelText('Team Name'), 'Test Team');
+    await userEvent.click(screen.getByText('Create Team'));
 
     await waitFor(() => {
       expect(mockAddTeam).toHaveBeenCalledWith(
@@ -136,7 +166,6 @@ describe('Team Operations', () => {
       name: 'Test Team', 
       players: []
     };
-    
     const mockUpdateTeam = jest.spyOn(dbService, 'updateTeam');
     jest.spyOn(dbService, 'getTeam').mockResolvedValue(mockTeam);
 


### PR DESCRIPTION
The following changes have been made to the team creation process:

* Create team now uses a modal instead of a new page
* On creation, we now open the Team page to add players
* Players are added inline instead of via a modal window

Closes #82