### PR TITLE
Fix Jest compatibility with uuid v14

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   presets: [
-    '@babel/preset-env',
+    ['@babel/preset-env', { targets: { node: 'current' } }],
     '@babel/preset-react',
     '@babel/preset-typescript'
   ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "react-bootstrap": "^2.10.9",
         "react-dom": "^19.0.0",
         "react-router-dom": "^7.0.0",
-        "uuid": "^11.1.0"
+        "uuid": "^14.0.0"
       },
       "devDependencies": {
         "@babel/core": "7.29.0",
@@ -11927,16 +11927,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/esm/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "react-bootstrap": "^2.10.9",
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.0.0",
-    "uuid": "^11.1.0"
+    "uuid": "^14.0.0"
   },
   "devDependencies": {
     "@babel/core": "7.29.0",


### PR DESCRIPTION
## Summary

- Fixes the failing CI on the Renovate uuid v14 PR (acbgbca/basketball-subs#169)
- Configures `@babel/preset-env` with `targets: { node: 'current' }` so Babel emits CommonJS output, allowing Jest to transform uuid v14's ESM-only dist files

This is the same class of fix as was applied for uuid v13 in 57f1e3b, but the root cause was that `@babel/preset-env` wasn't explicitly told to target Node (and therefore wasn't converting `export` statements to CommonJS).

## Test plan

- [x] All 4 Jest test suites (24 tests) pass locally with uuid v14

🤖 Generated with [Claude Code](https://claude.com/claude-code)